### PR TITLE
add for gold screens tests

### DIFF
--- a/src/__tests__/gold/GoldAnalizeScreen.test.tsx
+++ b/src/__tests__/gold/GoldAnalizeScreen.test.tsx
@@ -1,0 +1,51 @@
+/**
+ *
+ * Testsheet for GoldAnalize screen.
+ * 
+ * @author Jakub Świderski
+ *
+ */
+import React from 'react';
+import {render} from '@testing-library/react-native';
+import useSWR from 'swr';
+import {GoldAnalizeScreen} from '../../screens';
+
+jest.mock('swr', () => jest.fn());
+
+describe('GoldAnalizeScreen', () => {
+  const mockUseSWR = useSWR as jest.Mock;
+
+  beforeEach(() => {
+    mockUseSWR.mockReturnValue({
+      data: [
+        {data: '2023-06-01', cena: 100},
+        {data: '2023-06-02', cena: 105},
+        {data: '2023-06-03', cena: 110},
+      ],
+      error: null,
+      isLoading: false,
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('displays correct screen title', () => {
+    const {getByText} = render(<GoldAnalizeScreen />);
+    const titleText = getByText('Analiza Cen Złota');
+    expect(titleText).toBeTruthy();
+  });
+
+  test('displays the correct number of price notes', () => {
+    const {getByText} = render(<GoldAnalizeScreen />);
+    const notesText = getByText('Ostatnie 60 notowań ceny złota');
+    expect(notesText).toBeTruthy();
+  });
+
+  test('displays message for picking a day on the chart', () => {
+    const {getByText} = render(<GoldAnalizeScreen />);
+    const infoText = getByText('Kliknij na dzień, aby zobaczyć szczegóły');
+    expect(infoText).toBeTruthy();
+  });
+});

--- a/src/__tests__/gold/GoldCalculatorScreen.test.tsx
+++ b/src/__tests__/gold/GoldCalculatorScreen.test.tsx
@@ -1,0 +1,68 @@
+/**
+ *
+ * Testsheet for GoldCalculator screen.
+ * 
+ * @author Jakub Świderski
+ *
+ */
+import React from 'react';
+import {fireEvent, render} from '@testing-library/react-native';
+import {useNavigation} from '@react-navigation/native';
+import useSWR from 'swr';
+import {GoldCalculatorScreen} from '../../screens';
+import {act} from 'react-test-renderer';
+
+// Mocked navigation functions
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: jest.fn(),
+}));
+
+// Mocked API functions
+jest.mock('swr', () => jest.fn());
+jest.mock('../../api', () => ({
+  getDataFetcher: jest.fn(),
+}));
+
+describe('GoldCalculatorScreen', () => {
+  const mockUseNavigation = useNavigation as jest.Mock;
+  const mockUseSWR = useSWR as jest.Mock;
+
+  beforeEach(() => {
+    jest.useFakeTimers()
+    mockUseSWR.mockReturnValue({
+      data: [
+        {data: '2023-06-01', cena: 100},
+        {data: '2023-06-02', cena: 105},
+        {data: '2023-06-03', cena: 110},
+      ],
+      error: null,
+      isLoading: false,
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('calculates gold per gram price correctly', () => {
+    mockUseNavigation.mockReturnValue({navigate: jest.fn()});
+    const {getByTestId, getByText} = render(<GoldCalculatorScreen />);
+    const goldValueInput = getByTestId('gold-value-input');
+    act(() => {
+      fireEvent.changeText(goldValueInput, '2')
+    });
+    const calculatedPrice = getByText('220 PLN');
+    expect(calculatedPrice).toBeTruthy();
+  });
+
+  test('navigates to GoldAnalizeScreen correctly', () => {
+    const mockNavigate = jest.fn();
+    mockUseNavigation.mockReturnValue({navigate: mockNavigate});
+    const {getByText} = render(<GoldCalculatorScreen />);
+    const analizeButton = getByText('Analiza Cen');
+    act(() => {
+      fireEvent.press(analizeButton)
+    });
+    expect(mockNavigate).toHaveBeenCalledWith('GoldAnalizeScreen');
+  });
+});

--- a/src/screens/gold/GoldCalculatorScreen.tsx
+++ b/src/screens/gold/GoldCalculatorScreen.tsx
@@ -133,6 +133,7 @@ export const GoldCalculatorScreen: React.FC = () => {
               keyboardType="numeric"
               value={goldValue}
               onChangeText={text => setGoldValue(text)}
+              testID="gold-value-input"
             />
 
             {/* Gold grams label */}


### PR DESCRIPTION
On describe we can use:

const mockUseNavigation = useNavigation as jest.Mock;
const mockUseSWR = useSWR as jest.Mock;

and then make a mock to hook. Then You'll not need ts-ignore adnotation